### PR TITLE
UI improvements, error checking and computer domain group check

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,7 +18,6 @@ Checks are separated into categories. This allows them to be displayed in approp
 * LoggedOnUsers.cs - List all logged on users
 * OSVersion.cs - OS version information 
 * VirtualEnvironment.cs - Checks if we are operating in a virtualised environment
-* UserDomainGroups.cs - Gets the users domain group memberships
 * userEnvironmentVariables.cs - Grabs the environment variables applied to the current process 
 * SystemEnvironmentVariables.cs - Grabs system environment variables from the registry (HKLM)
 * NameServers.cs - Gets the DNS servers for each network interface 
@@ -31,6 +30,8 @@ Checks are separated into categories. This allows them to be displayed in approp
 * LocalAdmin.cs - Check if we are a local admin
 * Privileges.cs - List our current privileges.
 * UACLevel.cs - Get the UAC level
+* UserDomainGroups.cs - Gets the users domain group memberships
+* ComputerDomainGroups.cs - Gets the domain groups the computer is a member of
 
 **Software**
 * InstalledBrowsers.cs - Lists the browsers installed on the endpoint
@@ -38,10 +39,18 @@ Checks are separated into categories. This allows them to be displayed in approp
 **Credentials**
 * CredentialManager.cs - Retrieve credentials stored in Windows Credential Manager for the current user
 
+The following checks are currently marked as being not OpSec safe:
+
+* CredentialManager.cs
+* ComputerDomainGroups.cs
+* UserDomainGroups.cs
+
+You should review this configuration and update the OpSec tags as required.
+
 ## Disabling Checks
 All checks are enabled by default. However, as checks are loaded dynamically, it is possible to disable them.
 
-**Disbling a check**
+**Disabling a check**
 
 CheckBase includes a boolean "Enabled" property, which defaults to true. This can be set in the derived class by adding a constructor. The example below disables the CurrentUser check (CurrentUser.cs):
 
@@ -83,6 +92,8 @@ Derived classes must override the "ToString()" method defined in CheckBase. This
 
 Access to native methods is provided via classes in the "NativeMethods" folder. Each class is named after the dll it interacts with. 
 
+Checks are responsible for providing their own error handling. Current checks wrap the entire "check" method in a try-catch block, the use of this pattern is encouraged.  
+
 An example, empty check is shown below
 
 ```
@@ -101,7 +112,14 @@ namespace SitRep.Checks.Software
 
         public void Check()
         {
-            throw new NotImplementedException();
+            try
+            {
+                throw new NotImplementedException();
+            }
+            catch
+            {
+                Message = "Check failed [*]";
+            }
         }
 
         public override string ToString()

--- a/SitRep/Checks/Credentials/CredentialManager.cs
+++ b/SitRep/Checks/Credentials/CredentialManager.cs
@@ -19,32 +19,39 @@ namespace SitRep.Checks.Credentials
 
         public void Check()
         {
-            var builder = new StringBuilder();
-            Message = "No credentials found";
-            var creds = new List<Credential>();
-            int count;
-            IntPtr pCredentials;
-            bool ret = advapi32.CredEnumerate(null, 0, out count, out pCredentials);
-
-            if (ret)
+            try
             {
-                for (int i = 0; i < count; i++)
+                var builder = new StringBuilder();
+                Message = "No credentials found";
+                var creds = new List<Credential>();
+                int count;
+                IntPtr pCredentials;
+                bool ret = advapi32.CredEnumerate(null, 0, out count, out pCredentials);
+
+                if (ret)
                 {
-                    IntPtr credential = Marshal.ReadIntPtr(pCredentials, i * Marshal.SizeOf(typeof(IntPtr)));
-                    creds.Add(ReadCredential((advapi32.CREDENTIAL)Marshal.PtrToStructure(credential, typeof(advapi32.CREDENTIAL))));
+                    for (int i = 0; i < count; i++)
+                    {
+                        IntPtr credential = Marshal.ReadIntPtr(pCredentials, i * Marshal.SizeOf(typeof(IntPtr)));
+                        creds.Add(ReadCredential((advapi32.CREDENTIAL)Marshal.PtrToStructure(credential, typeof(advapi32.CREDENTIAL))));
+                    }
                 }
-            }
-            else
-            {
-                Message = "Error enumerating creds [*]";
-            }
+                else
+                {
+                    Message = "Error enumerating creds [*]";
+                }
 
-            foreach(var cred in creds)
-            {
-                builder.AppendLine(string.Format("\tApplication Name: {0}\r\n\t Username: {1} Password: {2} (Credential Type: {3})", 
-                    cred.ApplicationName, cred.UserName, cred.Password, cred.CredentialType.ToString()));
+                foreach (var cred in creds)
+                {
+                    builder.AppendLine(string.Format("\tApplication Name: {0}\r\n\t Username: {1} Password: {2} (Credential Type: {3})",
+                        cred.ApplicationName, cred.UserName, cred.Password, cred.CredentialType.ToString()));
+                }
+                Message = builder.ToString();
             }
-            Message = builder.ToString();
+            catch
+            {
+                Message = "Check failed [*]";
+            }
         }
 
         public override string ToString()

--- a/SitRep/Checks/Credentials/CredentialManager.cs
+++ b/SitRep/Checks/Credentials/CredentialManager.cs
@@ -38,7 +38,7 @@ namespace SitRep.Checks.Credentials
                 }
                 else
                 {
-                    Message = "Error enumerating creds [*]";
+                    Message = "\tNo credentials found";
                 }
 
                 foreach (var cred in creds)
@@ -46,7 +46,10 @@ namespace SitRep.Checks.Credentials
                     builder.AppendLine(string.Format("\tApplication Name: {0}\r\n\t Username: {1} Password: {2} (Credential Type: {3})",
                         cred.ApplicationName, cred.UserName, cred.Password, cred.CredentialType.ToString()));
                 }
-                Message = builder.ToString();
+                if (! string.IsNullOrWhiteSpace(builder.ToString()))
+                {
+                    Message = builder.ToString();
+                }
             }
             catch
             {

--- a/SitRep/Checks/Defences/AVProcesses.cs
+++ b/SitRep/Checks/Defences/AVProcesses.cs
@@ -20,7 +20,7 @@ namespace SitRep.Checks.Defences
             try
             {
                 var builder = new StringBuilder();
-
+                Message = "\tNo AV processes detected!";
                 var processList = Process.GetProcesses();
                 foreach (var process in processList)
                 {
@@ -29,7 +29,10 @@ namespace SitRep.Checks.Defences
                         builder.AppendLine("\t" + process.ProcessName);
                     }
                 }
-                Message = builder.ToString();
+                if(!string.IsNullOrWhiteSpace(builder.ToString()))
+                {
+                    Message = builder.ToString();
+                }
             }
             catch
             {

--- a/SitRep/Checks/Defences/AVProcesses.cs
+++ b/SitRep/Checks/Defences/AVProcesses.cs
@@ -17,17 +17,24 @@ namespace SitRep.Checks.Defences
 
         public void Check()
         {
-            var builder = new StringBuilder();
-
-            var processList = Process.GetProcesses();
-            foreach(var process in processList)
+            try
             {
-                if (AVProcessNames.Contains(process.ProcessName))
+                var builder = new StringBuilder();
+
+                var processList = Process.GetProcesses();
+                foreach (var process in processList)
                 {
-                    builder.AppendLine("\t" + process.ProcessName);
+                    if (AVProcessNames.Contains(process.ProcessName))
+                    {
+                        builder.AppendLine("\t" + process.ProcessName);
+                    }
                 }
+                Message = builder.ToString();
             }
-            Message = builder.ToString();
+            catch
+            {
+                Message = "Check failed [*]";
+            }
         }
         public override string ToString()
         {

--- a/SitRep/Checks/Environment/CurrentUser.cs
+++ b/SitRep/Checks/Environment/CurrentUser.cs
@@ -17,7 +17,14 @@ namespace SitRep.Checks.Environment
 
         public void Check()
         {
-            Message = System.Security.Principal.WindowsIdentity.GetCurrent().Name;
+            try
+            {
+                Message = System.Security.Principal.WindowsIdentity.GetCurrent().Name;
+            }
+            catch
+            {
+                Message = "Check failed [*]";
+            }
         }
 
         public override string ToString()

--- a/SitRep/Checks/Environment/DomainName.cs
+++ b/SitRep/Checks/Environment/DomainName.cs
@@ -14,9 +14,16 @@ namespace SitRep.Checks.Environment
 
         public void Check()
         {
-            IPGlobalProperties properties = IPGlobalProperties.GetIPGlobalProperties();
-            string dnsDomain = properties.DomainName;
-            Message = string.IsNullOrEmpty(dnsDomain) ? "NOT DOMAIN JOINED [*]" : dnsDomain;
+            try
+            {
+                IPGlobalProperties properties = IPGlobalProperties.GetIPGlobalProperties();
+                string dnsDomain = properties.DomainName;
+                Message = string.IsNullOrEmpty(dnsDomain) ? "NOT DOMAIN JOINED [*]" : dnsDomain;
+            }
+            catch
+            {
+                Message = "Check failed [*]";
+            }
         }
 
         public override string ToString()

--- a/SitRep/Checks/Environment/HostName.cs
+++ b/SitRep/Checks/Environment/HostName.cs
@@ -17,8 +17,15 @@ namespace SitRep.Checks.Environment
 
         public void Check()
         {
-            var strHostName = Dns.GetHostName();
-            Message = strHostName;
+            try
+            {
+                var strHostName = Dns.GetHostName();
+                Message = strHostName;
+            }
+            catch
+            {
+                Message = "Check failed [*]";
+            }
         }
 
         public override string ToString()

--- a/SitRep/Checks/Environment/LoggedOnUsers.cs
+++ b/SitRep/Checks/Environment/LoggedOnUsers.cs
@@ -49,7 +49,7 @@ namespace SitRep.Checks.Environment
             }
             catch
             {
-                Message = "Check failed [*]";
+                Message = "\tCheck failed [*]";
             }
         }
 

--- a/SitRep/Checks/Environment/NameServers.cs
+++ b/SitRep/Checks/Environment/NameServers.cs
@@ -39,7 +39,7 @@ namespace SitRep.Checks.Environment
             }
             catch
             {
-                Message = "Check failed [*]";
+                Message = "\tCheck failed [*]";
             }
         }
 

--- a/SitRep/Checks/Environment/NameServers.cs
+++ b/SitRep/Checks/Environment/NameServers.cs
@@ -17,23 +17,30 @@ namespace SitRep.Checks.Environment
 
         public void Check()
         {
-            Message = "No network interfaces found [*]";
-            var builder = new StringBuilder();
-            var adapters = NetworkInterface.GetAllNetworkInterfaces();
-            foreach(var adapter in adapters)
+            try
             {
-                var adapterProperties = adapter.GetIPProperties();
-                var dnsServers = adapterProperties.DnsAddresses;
-                if(dnsServers.Count > 0)
+                Message = "No network interfaces found [*]";
+                var builder = new StringBuilder();
+                var adapters = NetworkInterface.GetAllNetworkInterfaces();
+                foreach (var adapter in adapters)
                 {
-                    builder.AppendLine(string.Format("\t{0}", adapter.Description));
-                    foreach(var dns in dnsServers)
+                    var adapterProperties = adapter.GetIPProperties();
+                    var dnsServers = adapterProperties.DnsAddresses;
+                    if (dnsServers.Count > 0)
                     {
-                        builder.AppendLine(string.Format("\t\t{0}", dns.ToString()));
+                        builder.AppendLine(string.Format("\t{0}", adapter.Description));
+                        foreach (var dns in dnsServers)
+                        {
+                            builder.AppendLine(string.Format("\t\t{0}", dns.ToString()));
+                        }
                     }
                 }
+                Message = builder.ToString();
             }
-            Message = builder.ToString();
+            catch
+            {
+                Message = "Check failed [*]";
+            }
         }
 
         public override string ToString()

--- a/SitRep/Checks/Environment/OSVersion.cs
+++ b/SitRep/Checks/Environment/OSVersion.cs
@@ -17,20 +17,27 @@ namespace SitRep.Checks.Environment
 
         public void Check()
         {
-            var builder = new StringBuilder();
-            using (var searcher = new ManagementObjectSearcher("SELECT * FROM Win32_OperatingSystem"))
+            try
             {
-                var information = searcher.Get();
-                if (information != null)
+                var builder = new StringBuilder();
+                using (var searcher = new ManagementObjectSearcher("SELECT * FROM Win32_OperatingSystem"))
                 {
-                    foreach (var obj in information)
+                    var information = searcher.Get();
+                    if (information != null)
                     {
-                        builder.AppendLine(obj["Caption"].ToString() + " - " + obj["OSArchitecture"].ToString());
+                        foreach (var obj in information)
+                        {
+                            builder.AppendLine(obj["Caption"].ToString() + " - " + obj["OSArchitecture"].ToString());
+                        }
                     }
+
                 }
-         
+                Message = builder.ToString();
             }
-            Message = builder.ToString();
+            catch
+            {
+                Message = "Check failed [*]";
+            }
         }
 
         public override string ToString()

--- a/SitRep/Checks/Environment/SystemEnvironmentVariables.cs
+++ b/SitRep/Checks/Environment/SystemEnvironmentVariables.cs
@@ -16,20 +16,27 @@ namespace SitRep.Checks.Environment
 
         public void Check()
         {
-            var builder = new StringBuilder();
-            //Adapted from Seatbelt 
-            var items = Helpers.RegistryHelper.GetRegValues("HKLM", @"SYSTEM\CurrentControlSet\Control\Session Manager\Environment");
-            if(items == null || items.Count == 0)
+            try
             {
-                Message = "\tNo values loaded";
-                return;
-            }
-            foreach(var item in items)
-            {
-                builder.AppendLine(string.Format("\t{0} = {1}", item.Key, item.Value));
-            }
+                var builder = new StringBuilder();
+                //Adapted from Seatbelt 
+                var items = Helpers.RegistryHelper.GetRegValues("HKLM", @"SYSTEM\CurrentControlSet\Control\Session Manager\Environment");
+                if (items == null || items.Count == 0)
+                {
+                    Message = "\tNo values loaded";
+                    return;
+                }
+                foreach (var item in items)
+                {
+                    builder.AppendLine(string.Format("\t{0} = {1}", item.Key, item.Value));
+                }
 
-            Message = builder.ToString();
+                Message = builder.ToString();
+            }
+            catch
+            {
+                Message = "Check failed [*]";
+            }
         }
 
         public override string ToString()

--- a/SitRep/Checks/Environment/SystemEnvironmentVariables.cs
+++ b/SitRep/Checks/Environment/SystemEnvironmentVariables.cs
@@ -35,7 +35,7 @@ namespace SitRep.Checks.Environment
             }
             catch
             {
-                Message = "Check failed [*]";
+                Message = "\tCheck failed [*]";
             }
         }
 

--- a/SitRep/Checks/Environment/UserEnvironmentVariables.cs
+++ b/SitRep/Checks/Environment/UserEnvironmentVariables.cs
@@ -17,12 +17,19 @@ namespace SitRep.Checks.Environment
 
         public void Check()
         {
-            var builder = new StringBuilder();
-            foreach(DictionaryEntry item in System.Environment.GetEnvironmentVariables())
+            try
             {
-                builder.AppendLine(string.Format("\t{0} = {1}", item.Key, item.Value));
+                var builder = new StringBuilder();
+                foreach (DictionaryEntry item in System.Environment.GetEnvironmentVariables())
+                {
+                    builder.AppendLine(string.Format("\t{0} = {1}", item.Key, item.Value));
+                }
+                Message = builder.ToString();
             }
-            Message = builder.ToString();
+            catch
+            {
+                Message = "Check failed [*]";
+            }
         }
 
         public override string ToString()

--- a/SitRep/Checks/Environment/UserEnvironmentVariables.cs
+++ b/SitRep/Checks/Environment/UserEnvironmentVariables.cs
@@ -28,7 +28,7 @@ namespace SitRep.Checks.Environment
             }
             catch
             {
-                Message = "Check failed [*]";
+                Message = "\tCheck failed [*]";
             }
         }
 

--- a/SitRep/Checks/Environment/VirtualEnvionment.cs
+++ b/SitRep/Checks/Environment/VirtualEnvionment.cs
@@ -16,30 +16,37 @@ namespace SitRep.Checks.Environment
 
         public void Check()
         {
-            //seems WMI is the only way to do this. 
-            //https://stackoverflow.com/questions/498371/how-to-detect-if-my-application-is-running-in-a-virtual-machine
-            Message = "Host not virtualised";
-            using (var searcher = new System.Management.ManagementObjectSearcher("Select * from Win32_ComputerSystem"))
+            try
             {
-                using (var items = searcher.Get())
+                //seems WMI is the only way to do this. 
+                //https://stackoverflow.com/questions/498371/how-to-detect-if-my-application-is-running-in-a-virtual-machine
+                Message = "Host not virtualised";
+                using (var searcher = new System.Management.ManagementObjectSearcher("Select * from Win32_ComputerSystem"))
                 {
-                    foreach (var item in items)
+                    using (var items = searcher.Get())
                     {
-                        string manufacturer = item["Manufacturer"].ToString().ToLower();
-                        if (manufacturer == "microsoft corporation" && item["Model"].ToString().ToUpperInvariant().Contains("VIRTUAL"))
+                        foreach (var item in items)
                         {
-                            Message = "Virtualisation detected (Microsoft) [*]";
-                        }
-                        else if (manufacturer.Contains("vmware"))
-                        {
-                            Message = "Virtualisation detected (VMWare) [*]";
-                        }
-                        else if (item["Model"].ToString() == "VirtualBox")
-                        {
-                            Message = "Virtualisation detected (VirtualBox) [*]";
+                            string manufacturer = item["Manufacturer"].ToString().ToLower();
+                            if (manufacturer == "microsoft corporation" && item["Model"].ToString().ToUpperInvariant().Contains("VIRTUAL"))
+                            {
+                                Message = "Virtualisation detected (Microsoft) [*]";
+                            }
+                            else if (manufacturer.Contains("vmware"))
+                            {
+                                Message = "Virtualisation detected (VMWare) [*]";
+                            }
+                            else if (item["Model"].ToString() == "VirtualBox")
+                            {
+                                Message = "Virtualisation detected (VirtualBox) [*]";
+                            }
                         }
                     }
                 }
+            }
+            catch
+            {
+                Message = "Check failed [*]";
             }
         }
 

--- a/SitRep/Checks/Permissions/ComputerDomainGroups.cs
+++ b/SitRep/Checks/Permissions/ComputerDomainGroups.cs
@@ -1,0 +1,51 @@
+﻿using SitRep.Interfaces;
+using System;
+using System.Linq;
+using System.Text;
+using System.Net;
+using System.DirectoryServices.AccountManagement;
+
+namespace SitRep.Checks.Permissions
+{
+    class ComputerDomainGroups : CheckBase, ICheck
+    {
+        public bool IsOpsecSafe => false;
+
+        public int DisplayOrder => 5;
+
+        public Enums.Enums.CheckType CheckType => Enums.Enums.CheckType.Permissions;
+
+        public void Check()
+        {
+            var builder = new StringBuilder();
+            var domainName = System.Net.NetworkInformation.IPGlobalProperties.GetIPGlobalProperties().DomainName;
+            if (string.IsNullOrWhiteSpace(domainName))
+            {
+                Message = "Not domain joined";
+                return;
+            }
+            try
+            {
+                ComputerPrincipal principal = ComputerPrincipal.FindByIdentity(new PrincipalContext(ContextType.Domain, domainName), Dns.GetHostName());
+                foreach (GroupPrincipal group in principal.GetGroups())
+                {
+                    builder.AppendLine(string.Format("\t{0}", group));
+                }
+            }
+            catch(Exception ex)
+            {
+                builder.AppendLine(ex.ToString());
+                
+            }
+            Message = builder.ToString();
+        }
+
+        public override string ToString()
+        {
+            var builder = new StringBuilder();
+            builder.AppendLine("Computer domain groups:");
+            builder.AppendLine(Message);
+            return builder.ToString().Trim();
+        }
+    }
+}

--- a/SitRep/Checks/Permissions/ComputerDomainGroups.cs
+++ b/SitRep/Checks/Permissions/ComputerDomainGroups.cs
@@ -17,27 +17,28 @@ namespace SitRep.Checks.Permissions
 
         public void Check()
         {
-            var builder = new StringBuilder();
-            var domainName = System.Net.NetworkInformation.IPGlobalProperties.GetIPGlobalProperties().DomainName;
-            if (string.IsNullOrWhiteSpace(domainName))
-            {
-                Message = "Not domain joined";
-                return;
-            }
             try
             {
+                var builder = new StringBuilder();
+                var domainName = System.Net.NetworkInformation.IPGlobalProperties.GetIPGlobalProperties().DomainName;
+                if (string.IsNullOrWhiteSpace(domainName))
+                {
+                    Message = "Not domain joined";
+                    return;
+                }
+
                 ComputerPrincipal principal = ComputerPrincipal.FindByIdentity(new PrincipalContext(ContextType.Domain, domainName), Dns.GetHostName());
                 foreach (GroupPrincipal group in principal.GetGroups())
                 {
                     builder.AppendLine(string.Format("\t{0}", group));
                 }
+
+                Message = builder.ToString();
             }
-            catch(Exception ex)
+            catch
             {
-                builder.AppendLine(ex.ToString());
-                
+                Message = "Check failed [*]";
             }
-            Message = builder.ToString();
         }
 
         public override string ToString()

--- a/SitRep/Checks/Permissions/ComputerDomainGroups.cs
+++ b/SitRep/Checks/Permissions/ComputerDomainGroups.cs
@@ -23,7 +23,7 @@ namespace SitRep.Checks.Permissions
                 var domainName = System.Net.NetworkInformation.IPGlobalProperties.GetIPGlobalProperties().DomainName;
                 if (string.IsNullOrWhiteSpace(domainName))
                 {
-                    Message = "Not domain joined";
+                    Message = "\tNot domain joined";
                     return;
                 }
 
@@ -37,7 +37,7 @@ namespace SitRep.Checks.Permissions
             }
             catch
             {
-                Message = "Check failed [*]";
+                Message = "\tCheck failed [*]";
             }
         }
 

--- a/SitRep/Checks/Permissions/Integrity.cs
+++ b/SitRep/Checks/Permissions/Integrity.cs
@@ -17,12 +17,19 @@ namespace SitRep.Checks.Permissions
 
         public void Check()
         {
-            Message = "Not in High Integrity context";
-            var identity = WindowsIdentity.GetCurrent();
-            var principal = new WindowsPrincipal(identity);
-            if (principal.IsInRole(WindowsBuiltInRole.Administrator))
+            try
             {
-                Message = "In High Integrity context [*]";
+                Message = "Not in High Integrity context";
+                var identity = WindowsIdentity.GetCurrent();
+                var principal = new WindowsPrincipal(identity);
+                if (principal.IsInRole(WindowsBuiltInRole.Administrator))
+                {
+                    Message = "In High Integrity context [*]";
+                }
+            }
+            catch
+            {
+                Message = "Check failed [*]";
             }
         }
 

--- a/SitRep/Checks/Permissions/LocalAdmin.cs
+++ b/SitRep/Checks/Permissions/LocalAdmin.cs
@@ -19,18 +19,25 @@ namespace SitRep.Checks.Permissions
 
         public void Check()
         {
-            Message = "Not a local admin";
-            
-            //adapted from Seatbelt
-            //checks if the "S-1-5-32-544" in the current token groups set, meaning the user is a local administrator
-            string[] SIDs = GetTokenGroupSIDs();
-
-            foreach (string SID in SIDs)
+            try
             {
-                if (SID == "S-1-5-32-544")
+                Message = "Not a local admin";
+
+                //adapted from Seatbelt
+                //checks if the "S-1-5-32-544" in the current token groups set, meaning the user is a local administrator
+                string[] SIDs = GetTokenGroupSIDs();
+
+                foreach (string SID in SIDs)
                 {
-                    Message = "Current user is a Local admin [*]";
+                    if (SID == "S-1-5-32-544")
+                    {
+                        Message = "Current user is a Local admin [*]";
+                    }
                 }
+            }
+            catch
+            {
+                Message = "Check failed [*]";
             }
         }
 

--- a/SitRep/Checks/Permissions/Privileges.cs
+++ b/SitRep/Checks/Permissions/Privileges.cs
@@ -72,7 +72,7 @@ namespace SitRep.Checks.Permissions
             }
             catch
             {
-                Message = "Check failed [*]";
+                Message = "\tCheck failed [*]";
             }
 
         }

--- a/SitRep/Checks/Permissions/Privileges.cs
+++ b/SitRep/Checks/Permissions/Privileges.cs
@@ -19,9 +19,11 @@ namespace SitRep.Checks.Permissions
 
         public void Check()
         {
-            var builder = new StringBuilder();
+            try
+            {
+                var builder = new StringBuilder();
 
-            var specialPrivileges = new List<string>()
+                var specialPrivileges = new List<string>()
             {
                 "SeSecurityPrivilege",
                 "SeTakeOwnershipPrivilege",
@@ -33,40 +35,45 @@ namespace SitRep.Checks.Permissions
                 "SeImpersonatePrivilege",
                 "SeTcbPrivilege"
             };
-            int TokenInfLength = 0;
-            IntPtr ThisHandle = WindowsIdentity.GetCurrent().Token;
-            advapi32.GetTokenInformation(ThisHandle, advapi32.TOKEN_INFORMATION_CLASS.TokenPrivileges, IntPtr.Zero, TokenInfLength, out TokenInfLength);
-            IntPtr TokenInformation = Marshal.AllocHGlobal(TokenInfLength);
+                int TokenInfLength = 0;
+                IntPtr ThisHandle = WindowsIdentity.GetCurrent().Token;
+                advapi32.GetTokenInformation(ThisHandle, advapi32.TOKEN_INFORMATION_CLASS.TokenPrivileges, IntPtr.Zero, TokenInfLength, out TokenInfLength);
+                IntPtr TokenInformation = Marshal.AllocHGlobal(TokenInfLength);
 
-            if (advapi32.GetTokenInformation(WindowsIdentity.GetCurrent().Token, advapi32.TOKEN_INFORMATION_CLASS.TokenPrivileges, TokenInformation, TokenInfLength, out TokenInfLength))
-            {
-                var ThisPrivilegeSet = (advapi32.TOKEN_PRIVILEGES)Marshal.PtrToStructure(TokenInformation, typeof(advapi32.TOKEN_PRIVILEGES));
-                for (int i = 0; i < ThisPrivilegeSet.PrivilegeCount; i++)
+                if (advapi32.GetTokenInformation(WindowsIdentity.GetCurrent().Token, advapi32.TOKEN_INFORMATION_CLASS.TokenPrivileges, TokenInformation, TokenInfLength, out TokenInfLength))
                 {
-                    advapi32.LUID_AND_ATTRIBUTES laa = ThisPrivilegeSet.Privileges[i];
-                    System.Text.StringBuilder StrBuilder = new System.Text.StringBuilder();
-                    int LuidNameLen = 0;
-                    IntPtr LuidPointer = Marshal.AllocHGlobal(Marshal.SizeOf(laa.Luid));
-                    Marshal.StructureToPtr(laa.Luid, LuidPointer, true);
-                    advapi32.LookupPrivilegeName(null, LuidPointer, null, ref LuidNameLen);
-                    StrBuilder.EnsureCapacity(LuidNameLen + 1);
-
-                    if(advapi32.LookupPrivilegeName(null, LuidPointer, StrBuilder, ref LuidNameLen))
+                    var ThisPrivilegeSet = (advapi32.TOKEN_PRIVILEGES)Marshal.PtrToStructure(TokenInformation, typeof(advapi32.TOKEN_PRIVILEGES));
+                    for (int i = 0; i < ThisPrivilegeSet.PrivilegeCount; i++)
                     {
-                        var privilage = StrBuilder.ToString();
-                        if (specialPrivileges.Contains(privilage))
+                        advapi32.LUID_AND_ATTRIBUTES laa = ThisPrivilegeSet.Privileges[i];
+                        System.Text.StringBuilder StrBuilder = new System.Text.StringBuilder();
+                        int LuidNameLen = 0;
+                        IntPtr LuidPointer = Marshal.AllocHGlobal(Marshal.SizeOf(laa.Luid));
+                        Marshal.StructureToPtr(laa.Luid, LuidPointer, true);
+                        advapi32.LookupPrivilegeName(null, LuidPointer, null, ref LuidNameLen);
+                        StrBuilder.EnsureCapacity(LuidNameLen + 1);
+
+                        if (advapi32.LookupPrivilegeName(null, LuidPointer, StrBuilder, ref LuidNameLen))
                         {
-                            builder.AppendLine("\t" + privilage + " [*]");
+                            var privilage = StrBuilder.ToString();
+                            if (specialPrivileges.Contains(privilage))
+                            {
+                                builder.AppendLine("\t" + privilage + " [*]");
+                            }
+                            else
+                            {
+                                builder.AppendLine("\t" + privilage);
+                            }
                         }
-                        else
-                        {
-                            builder.AppendLine("\t" + privilage);
-                        }
+                        Marshal.FreeHGlobal(LuidPointer);
                     }
-                    Marshal.FreeHGlobal(LuidPointer);
                 }
+                Message = builder.ToString();
             }
-            Message = builder.ToString();
+            catch
+            {
+                Message = "Check failed [*]";
+            }
 
         }
 

--- a/SitRep/Checks/Permissions/UACLevel.cs
+++ b/SitRep/Checks/Permissions/UACLevel.cs
@@ -17,30 +17,37 @@ namespace SitRep.Checks.Permissions
 
         public void Check()
         {
-            string ConsentPromptBehaviorAdmin = RegistryHelper.GetRegValue("HKLM", "SOFTWARE\\Microsoft\\Windows\\CurrentVersion\\Policies\\System", "ConsentPromptBehaviorAdmin");
-            switch (ConsentPromptBehaviorAdmin)
+            try
             {
-                case "0":
-                    Message = "No prompting [*]";
-                    break;
-                case "1":
-                    Message = "PromptOnSecureDesktop";
-                    break;
-                case "2":
-                    Message = " PromptPermitDenyOnSecureDesktop";
-                    break;
-                case "3":
-                    Message = "PromptForCredsNotOnSecureDesktop";
-                    break;
-                case "4":
-                    Message = "PromptForPermitDenyNotOnSecureDesktop";
-                    break;
-                case "5":
-                    Message = "PromptForNonWindowsBinaries";
-                    break;
-                default:
-                    Message = "PromptForNonWindowsBinaries";
-                    break;
+                string ConsentPromptBehaviorAdmin = RegistryHelper.GetRegValue("HKLM", "SOFTWARE\\Microsoft\\Windows\\CurrentVersion\\Policies\\System", "ConsentPromptBehaviorAdmin");
+                switch (ConsentPromptBehaviorAdmin)
+                {
+                    case "0":
+                        Message = "No prompting [*]";
+                        break;
+                    case "1":
+                        Message = "PromptOnSecureDesktop";
+                        break;
+                    case "2":
+                        Message = " PromptPermitDenyOnSecureDesktop";
+                        break;
+                    case "3":
+                        Message = "PromptForCredsNotOnSecureDesktop";
+                        break;
+                    case "4":
+                        Message = "PromptForPermitDenyNotOnSecureDesktop";
+                        break;
+                    case "5":
+                        Message = "PromptForNonWindowsBinaries";
+                        break;
+                    default:
+                        Message = "PromptForNonWindowsBinaries";
+                        break;
+                }
+            }
+            catch
+            {
+                Message = "Check failed [*]";
             }
         }
 

--- a/SitRep/Checks/Permissions/UserDomainGroups.cs
+++ b/SitRep/Checks/Permissions/UserDomainGroups.cs
@@ -51,7 +51,7 @@ namespace SitRep.Checks.Permissions
             var builder = new StringBuilder();
             builder.AppendLine("User Domain Groups:");
             builder.AppendLine(Message);
-            return builder.ToString();
+            return builder.ToString().Trim();
         }
 
         private bool IsDomainJoined()

--- a/SitRep/Checks/Permissions/UserDomainGroups.cs
+++ b/SitRep/Checks/Permissions/UserDomainGroups.cs
@@ -49,7 +49,7 @@ namespace SitRep.Checks.Permissions
             }
             catch
             {
-                Message = "Check failed [*]";
+                Message = "\tCheck failed [*]";
             }
         }
 

--- a/SitRep/Checks/Permissions/UserDomainGroups.cs
+++ b/SitRep/Checks/Permissions/UserDomainGroups.cs
@@ -18,32 +18,39 @@ namespace SitRep.Checks.Permissions
 
         public void Check()
         {
-            //First, check if we are domain joined. otherwise, we dont want to run this code...
-            if (!IsDomainJoined())
+            try
             {
-                Message = "\tHost is not domain joined";
-                return;
-            }
-            var builder = new StringBuilder();
-            //adapted from https://stackoverflow.com/questions/5309988/how-to-get-the-groups-of-a-user-in-active-directory-c-asp-net
-            var groups = new List<string>();
-            var UPN = System.DirectoryServices.AccountManagement.UserPrincipal.Current.UserPrincipalName;
-            var wi = new WindowsIdentity(UPN);
-
-            foreach (var group in wi.Groups)
-            {
-                try
+                //First, check if we are domain joined. otherwise, we dont want to run this code...
+                if (!IsDomainJoined())
                 {
-                    groups.Add(group.Translate(typeof(NTAccount)).ToString());
+                    Message = "\tHost is not domain joined";
+                    return;
                 }
-                catch { }
+                var builder = new StringBuilder();
+                //adapted from https://stackoverflow.com/questions/5309988/how-to-get-the-groups-of-a-user-in-active-directory-c-asp-net
+                var groups = new List<string>();
+                var UPN = System.DirectoryServices.AccountManagement.UserPrincipal.Current.UserPrincipalName;
+                var wi = new WindowsIdentity(UPN);
+
+                foreach (var group in wi.Groups)
+                {
+                    try
+                    {
+                        groups.Add(group.Translate(typeof(NTAccount)).ToString());
+                    }
+                    catch { }
+                }
+                groups.Sort();
+                foreach (var group in groups)
+                {
+                    builder.AppendLine("\t" + group);
+                }
+                Message = builder.ToString();
             }
-            groups.Sort();
-            foreach (var group in groups)
+            catch
             {
-                builder.AppendLine("\t" + group);
+                Message = "Check failed [*]";
             }
-            Message = builder.ToString();
         }
 
         public override string ToString()

--- a/SitRep/Checks/Software/InstalledBrowsers.cs
+++ b/SitRep/Checks/Software/InstalledBrowsers.cs
@@ -52,7 +52,7 @@ namespace SitRep.Checks.Software
             }
             catch
             {
-                Message = "Check failed [*]";
+                Message = "\tCheck failed [*]";
             }
         }
 

--- a/SitRep/Checks/Software/InstalledBrowsers.cs
+++ b/SitRep/Checks/Software/InstalledBrowsers.cs
@@ -16,37 +16,44 @@ namespace SitRep.Checks.Software
         public Enums.Enums.CheckType CheckType => Enums.Enums.CheckType.Software;
         public void Check()
         {
-            //adapted from https://github.com/MintPlayer/PlatformBrowser/edit/master/MintPlayer.PlatformBrowser/PlatformBrowser.cs
-            var builder = new StringBuilder();
-
-            //get browser info from registry 
-            var internetKey = RegistryHelper.GetRegSubkeys("HKLM", @"SOFTWARE\WOW6432Node\Clients\StartMenuInternet");
-            if (internetKey == null)
+            try
             {
-                internetKey = RegistryHelper.GetRegSubkeys("HKLM", @"SOFTWARE\Clients\StartMenuInternet");
-            }
+                //adapted from https://github.com/MintPlayer/PlatformBrowser/edit/master/MintPlayer.PlatformBrowser/PlatformBrowser.cs
+                var builder = new StringBuilder();
 
-            foreach(var browser in internetKey)
-            {
-                builder.AppendLine("\t" + browser);
-            }
-
-            //Apparently Edge is special... 
-            var systemAppsFolder = @"C:\Windows\SystemApps\";
-            if (System.IO.Directory.Exists(systemAppsFolder))
-            {
-                var directories = System.IO.Directory.GetDirectories(systemAppsFolder);
-                var edgeFolder = directories.FirstOrDefault(d => d.StartsWith($"{systemAppsFolder}Microsoft.MicrosoftEdge_"));
-
-                if(edgeFolder != null)
+                //get browser info from registry 
+                var internetKey = RegistryHelper.GetRegSubkeys("HKLM", @"SOFTWARE\WOW6432Node\Clients\StartMenuInternet");
+                if (internetKey == null)
                 {
-                    if (System.IO.File.Exists($@"{edgeFolder}\MicrosoftEdge.exe"))
+                    internetKey = RegistryHelper.GetRegSubkeys("HKLM", @"SOFTWARE\Clients\StartMenuInternet");
+                }
+
+                foreach (var browser in internetKey)
+                {
+                    builder.AppendLine("\t" + browser);
+                }
+
+                //Apparently Edge is special... 
+                var systemAppsFolder = @"C:\Windows\SystemApps\";
+                if (System.IO.Directory.Exists(systemAppsFolder))
+                {
+                    var directories = System.IO.Directory.GetDirectories(systemAppsFolder);
+                    var edgeFolder = directories.FirstOrDefault(d => d.StartsWith($"{systemAppsFolder}Microsoft.MicrosoftEdge_"));
+
+                    if (edgeFolder != null)
                     {
-                        builder.AppendLine("\t" + "Microsoft Edge");
+                        if (System.IO.File.Exists($@"{edgeFolder}\MicrosoftEdge.exe"))
+                        {
+                            builder.AppendLine("\t" + "Microsoft Edge");
+                        }
                     }
                 }
+                Message = builder.ToString();
             }
-            Message = builder.ToString();
+            catch
+            {
+                Message = "Check failed [*]";
+            }
         }
 
         public override string ToString()

--- a/SitRep/SitRep.csproj
+++ b/SitRep/SitRep.csproj
@@ -37,6 +37,7 @@
   <ItemGroup>
     <Reference Include="System" />
     <Reference Include="System.Core" />
+    <Reference Include="System.DirectoryServices" />
     <Reference Include="System.DirectoryServices.AccountManagement" />
     <Reference Include="System.Management" />
     <Reference Include="System.ServiceProcess" />
@@ -50,6 +51,7 @@
     <Compile Include="Checks\CheckBase.cs" />
     <Compile Include="Checks\Credentials\CredentialManager.cs" />
     <Compile Include="Checks\Defences\AVProcesses.cs" />
+    <Compile Include="Checks\Permissions\ComputerDomainGroups.cs" />
     <Compile Include="Checks\Environment\CurrentUser.cs" />
     <Compile Include="Checks\Environment\DomainName.cs" />
     <Compile Include="Checks\Environment\NameServers.cs" />
@@ -58,7 +60,7 @@
     <Compile Include="Checks\Environment\HostName.cs" />
     <Compile Include="Checks\Environment\LoggedOnUsers.cs" />
     <Compile Include="Checks\Environment\OSVersion.cs" />
-    <Compile Include="Checks\Environment\UserDomainGroups.cs" />
+    <Compile Include="Checks\Permissions\UserDomainGroups.cs" />
     <Compile Include="Checks\Environment\VirtualEnvionment.cs" />
     <Compile Include="Checks\Permissions\Integrity.cs" />
     <Compile Include="Checks\Permissions\LocalAdmin.cs" />


### PR DESCRIPTION
Added a new check for computer domain group memberships
Moved the group membership checks to permissions rather than environment namespace
Updated all check methods to include proper error handling
UI now has proper text formatting for errors
fixed bug where default check messages were overwritten on failure