### PR TITLE
Added Process Check

### DIFF
--- a/SitRep/Checks/Environment/Processes.cs
+++ b/SitRep/Checks/Environment/Processes.cs
@@ -1,0 +1,74 @@
+﻿using SitRep.Interfaces;
+using System;
+using System.Text;
+using static SitRep.Enums.Enums;
+using SitRep.NativeMethods;
+using System.Diagnostics;
+using System.Security.Principal;
+
+namespace SitRep.Checks.Credentials
+{
+    class TestCheck : CheckBase, ICheck
+    {
+        public int DisplayOrder => 10;
+
+        public bool IsOpsecSafe => false;
+
+        public CheckType CheckType => CheckType.Environment;
+
+        public void Check()
+        {
+            var builder = new StringBuilder();
+            var allProcesses = Process.GetProcesses();
+            string user;
+            try
+            {
+                builder.AppendLine($"\t{"Process ID",10}\t{"Session ID",10}\t{"Process Owner",10}\t{"Process Name",10}");
+
+                foreach (Process p in allProcesses)
+                {
+                    user = GetProcessOwner(p);
+                    builder.AppendLine(string.Format($"\t{p.Id,-10}\t{p.SessionId,-10}\t{user,-10}\t{p.ProcessName,-10}"));
+                }
+
+                Message = builder.ToString();
+            }
+            catch
+            {
+                Message = "\tCheck failed [*]";
+            }
+        }
+
+        public override string ToString()
+        {
+            var builder = new StringBuilder();
+            builder.AppendLine("Running Processes:");
+            builder.AppendLine(Message);
+            return builder.ToString().Trim();
+        }
+
+        // Thanks bytecode77 @ https://stackoverflow.com/a/38676215
+        private static string GetProcessOwner(Process process)
+        {
+            IntPtr processHandle = IntPtr.Zero;
+            try
+            {
+                advapi32.OpenProcessToken(process.Handle, 8, out processHandle);
+                WindowsIdentity wi = new WindowsIdentity(processHandle);
+                string user = wi.Name;
+                return user.Contains(@"\") ? user.Substring(user.IndexOf(@"\") + 1) : user;
+            }
+            catch
+            {
+                return null;
+            }
+            finally
+            {
+                if (processHandle != IntPtr.Zero)
+                {
+                    kernel32.CloseHandle(processHandle);
+                }
+            }
+        }
+    }
+}

--- a/SitRep/NativeMethods/Kernel32.cs
+++ b/SitRep/NativeMethods/Kernel32.cs
@@ -15,5 +15,4 @@ namespace SitRep.NativeMethods
         [return: MarshalAs(UnmanagedType.Bool)]
         public static extern bool CloseHandle(IntPtr hObject);
     }
-    
 }

--- a/SitRep/NativeMethods/Kernel32.cs
+++ b/SitRep/NativeMethods/Kernel32.cs
@@ -10,5 +10,10 @@ namespace SitRep.NativeMethods
     {
         [DllImport("kernel32.dll")]
         public static extern IntPtr LocalFree(IntPtr hMem);
+        
+        [DllImport("kernel32.dll", SetLastError = true)]
+        [return: MarshalAs(UnmanagedType.Bool)]
+        public static extern bool CloseHandle(IntPtr hObject);
     }
+    
 }

--- a/SitRep/NativeMethods/advapi32.cs
+++ b/SitRep/NativeMethods/advapi32.cs
@@ -39,6 +39,9 @@ namespace SitRep.NativeMethods
             int TokenInformationLength,
             out int ReturnLength);
 
+        [DllImport("advapi32.dll", SetLastError = true)]
+        public static extern bool OpenProcessToken(IntPtr ProcessHandle, uint DesiredAccess, out IntPtr TokenHandle);
+        
         [StructLayout(LayoutKind.Sequential)]
         public struct SID_AND_ATTRIBUTES
         {


### PR DESCRIPTION
This PR adds a check called Processes that lists all running process names, their PID, their session ID, and their owner. It uses the Windows API, so two new P/Invoke signatures were added, `CloseHandle` and `OpenProcessToken`.

I'm not 100% how Opsec safe this is, so I preemptively set it to unsafe, just in case.